### PR TITLE
Hk docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This extension consists of 2 separate modules: REST Client and Warp REST.
 
 ## REST Client
-Choose this module if you want to test from client side only (black box).
+Choose this module if you want to test from client side only (black box). [Click here for more documentation.](rest-client/README.md)
 
 ## Warp REST
-Choose this module if you need to do assertions inside container.
+Choose this module if you need to do assertions inside container. [Click here for more documentation.](warp-rest/README.md)

--- a/rest-client/README.md
+++ b/rest-client/README.md
@@ -122,8 +122,8 @@ The objects we're passing (i.e. Customer) are being marshaled by JAXB, Jackson, 
     }
 ```
 
-In the example above we want to do POST against "rest/customer", send customer in JSON fromat but add some field "biskupa" that actually does not exist in Customer class. What's more we want to specify authorization header to mimic Basic Authorization and instruct serve to return response in ATOM format.
-Of course this test will not pass (we told server to respond in ATOM format and then we do assertion for JSON), but it's purpose here is to show you what cool customization we can do.
+In the example above we want to do POST against "rest/customer", send customer in JSON format but add some field "biskupa" that actually does not exist in Customer class. What's more we want to specify authorization header to mimic Basic Authorization and instruct server to return response in ATOM format.
+Of course this test will not pass (we told server to respond in ATOM format and then we do assertion for JSON), but it's purpose here is to show you the kind of cool customizations we can do.
 
 Notice that `org.jboss.resteasy.client.jaxrs.ResteasyWebTarget` is available only if you use `arquillian-rest-client-impl-3x`. If you use `arquillian-rest-client-impl-2x` then you should inject `org.jboss.resteasy.client.ClientRequest`. More details at the end.
 

--- a/rest-client/README.md
+++ b/rest-client/README.md
@@ -80,7 +80,7 @@ It's an interface properly decorated with JAX-RS annotations.
 It might be a nice way to extract your app's REST resources interfaces into separate module so that it can be used later on in tests and clients.
 
 ##What if I want to be naughty?
-Let's suppose you want to test what will happen if you make GET request to "/rest/customer" but tell server you accept only YAML. Nothing simpler. Just put @Consumes annotation on your test method. It will overwrite annotations from CustomerResource interface.
+Let's suppose you want to test what will happen if you make GET request to "/rest/customer" but tell server you accept only YAML. Nothing simpler. Just put `@Consumes` annotation on your test method. It will overwrite annotations from CustomerResource interface.
 
 ```java
     @Test
@@ -125,7 +125,7 @@ The objects we're passing (i.e. Customer) are being marshaled by JAXB, Jackson, 
 In the example above we want to do POST against "rest/customer", send customer in JSON fromat but add some field "biskupa" that actually does not exist in Customer class. What's more we want to specify authorization header to mimic Basic Authorization and instruct serve to return response in ATOM format.
 Of course this test will not pass (we told server to respond in ATOM format and then we do assertion for JSON), but it's purpose here is to show you what cool customization we can do.
 
-Notice that `org.jboss.resteasy.client.jaxrs.ResteasyWebTarget` is available only if you use `arquillian-rest-client-impl-3x`. If you use arquillian-rest-client-impl-2x then you should inject `org.jboss.resteasy.client.ClientRequest`. More details at the end.
+Notice that `org.jboss.resteasy.client.jaxrs.ResteasyWebTarget` is available only if you use `arquillian-rest-client-impl-3x`. If you use `arquillian-rest-client-impl-2x` then you should inject `org.jboss.resteasy.client.ClientRequest`. More details at the end.
 
 ##So how does this extension know the URL of my API?
 Well, Arquillian knows very well where it has deployed the archive. The path to API is taken from @ArquillianResteasyResource which by default is "rest". If your API is located somewhere else then simply specify it i.e.: `@ArquillianResteasyResource("api/v2")`. Note lack of preceeding and trailing slashes.

--- a/rest-client/README.md
+++ b/rest-client/README.md
@@ -5,12 +5,13 @@ Arquillian REST Client Extension allows you to test your RESTful applications on
 Sometimes you need to test your REST app as a black box. You know the interface (the contract), you have some input and know what results you expect.
 For that purpose Arquillian REST Client Extension is your friend.
 
-But wait! Why do I need extension for that? Can't I simply deploy test app with Arquillian Core and simply use HttpClient?
+But wait! Why do I need an extension for that? Can't I simply deploy the test app with Arquillian Core and use `HttpClient`?
 Yes you can, but don't you want to make your code shorter?
 
 ##Let's see how short it can be.
 Here is fragment from functional tests of our extension:
 
+```java
     @RunWith(Arquillian.class)
     public class RestClientTestCase {
 
@@ -47,14 +48,16 @@ Here is fragment from functional tests of our extension:
             assertEquals(name, result.getName());
         }
     }
+```
+
 Look at line 7. Note that after Arquillian deploys test archive to container (i.e. AS7) our tests should run from client JVM (outside of container).
-Now our test method accepts single param annotated with @ArquillianResteasyResource. That annotation tells REST extension that is should create some REST client artifact (in this case it's a client proxy to CustomerResource).
+Now our test method accepts single param annotated with `@ArquillianResteasyResource`. That annotation tells REST extension that is should create some REST client artifact (in this case it's a client proxy to CustomerResource).
 That's it. No opening HTTP connections, no JSON/XML/etc. And still under the hood there are HTTP requests flying back and forth between our test and server.
 
 ##Ok, but what the hell is CustomerResource?
-It's interface properly decorated with JAX-RS annotations.
+It's an interface properly decorated with JAX-RS annotations.
 
-
+```java
     @Path("/customer")
     public interface CustomerResource {
 
@@ -73,22 +76,27 @@ It's interface properly decorated with JAX-RS annotations.
         @Path("/")
         Customer createCustomer(Customer customer);
     }
+```
 It might be a nice way to extract your app's REST resources interfaces into separate module so that it can be used later on in tests and clients.
 
 ##What if I want to be naughty?
 Let's suppose you want to test what will happen if you make GET request to "/rest/customer" but tell server you accept only YAML. Nothing simpler. Just put @Consumes annotation on your test method. It will overwrite annotations from CustomerResource interface.
 
+```java
     @Test
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_XML)
     public void createCustomer(@ArquillianResteasyResource CustomerResource customerResource) {
     //      ...
     }
-Actually all annotations on test method will be copied to CustomerResource, except for @Test.
+```
+
+Actually all annotations on test method will be copied to CustomerResource, except for `@Test`.
 
 ##Nice, but what if I need a bit more control
 The objects we're passing (i.e. Customer) are being marshaled by JAXB, Jackson, or whatever you configure. But what if you want to send some additional headers, tell server about accepted encoding or post manually created and invalid JSON object? For that we need to inject different resource.
 
+```java
     /**
      * We can inject either proxy or a ResteasyWebTarget for low level manipulations and assertions.
      *
@@ -112,20 +120,23 @@ The objects we're passing (i.e. Customer) are being marshaled by JAXB, Jackson, 
         assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
         assertEquals(HttpStatus.SC_OK, response.getStatus());
     }
+```
 
 In the example above we want to do POST against "rest/customer", send customer in JSON fromat but add some field "biskupa" that actually does not exist in Customer class. What's more we want to specify authorization header to mimic Basic Authorization and instruct serve to return response in ATOM format.
 Of course this test will not pass (we told server to respond in ATOM format and then we do assertion for JSON), but it's purpose here is to show you what cool customization we can do.
 
-Notice that org.jboss.resteasy.client.jaxrs.ResteasyWebTarget is available only if you use arquillian-rest-client-impl-3x. If you use arquillian-rest-client-impl-2x then you should inject org.jboss.resteasy.client.ClientRequest. More details at the end.
+Notice that `org.jboss.resteasy.client.jaxrs.ResteasyWebTarget` is available only if you use `arquillian-rest-client-impl-3x`. If you use arquillian-rest-client-impl-2x then you should inject `org.jboss.resteasy.client.ClientRequest`. More details at the end.
 
 ##So how does this extension know the URL of my API?
-Well, Arquillian knows very well where it has deployed the archive. The path to API is taken from @ArquillianResteasyResource which by default is "rest". If your API is located somewhere else then simply specify it i.e.: @ArquillianResteasyResource("api/v2"). Note lack of preceeding and trailing slashes.
+Well, Arquillian knows very well where it has deployed the archive. The path to API is taken from @ArquillianResteasyResource which by default is "rest". If your API is located somewhere else then simply specify it i.e.: `@ArquillianResteasyResource("api/v2")`. Note lack of preceeding and trailing slashes.
+
 
 ##So what do I need in my POM?
 This depends. The extension leverages RestEasy client, but since there are major differences between RestEasy 2.x and 3.x the extension ships with two different implementations, one for each RestEasy version.
 
 Here are dependencies for Arquillian REST Client Extension if you choose RestEasy 3.x:
 
+```xml
     <dependency>
         <groupId>org.jboss.arquillian.extension</groupId>
         <artifactId>arquillian-rest-client-api</artifactId>
@@ -138,21 +149,26 @@ Here are dependencies for Arquillian REST Client Extension if you choose RestEas
         <version>1.0.0.Final-SNAPSHOT</version>
         <scope>test</scope>
     </dependency>
+```
 
 Depending on data formats you want to use to communicate with your REST app you need to also add appropriate marshallers.
 JSON:
 
+```xml
     <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jackson-provider</artifactId>
         <version>${version.resteasy}</version>
         <scope>test</scope>
     </dependency>
+```
 XML:
 
+```xml
     <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxb-provider</artifactId>
         <version>${version.resteasy}</version>
         <scope>test</scope>
     </dependency>
+```

--- a/warp-rest/README.md
+++ b/warp-rest/README.md
@@ -19,7 +19,7 @@ incoming request, response, status code, headers and i.e. returned entity.
 
 In order to setup the project one need only to add one of the REST implementations for the targeted JAX-RS version.
 
-```
+```xml
    <dependency>
        <groupId>org.jboss.arquillian.extension</groupId>
        <artifactId>arquillian-rest-warp-impl-jaxrs-2.0</artifactId>
@@ -38,7 +38,7 @@ automatically. In order cases the proper interceptor will have to be properly re
 
 ### Example test:
 
-```
+```java
    @WarpTest
    @RunWith(Arquillian.class)
    public class StockServiceResourceTestCase {


### PR DESCRIPTION
This improves some aspects to the documentation that is a bit lacking at the moment. Mainly it

* links to both the warp-rest and rest-client readme from the toplevel readme. I only realized there was more explanation in there after a few days of search.
* adds language specific syntax highlighting to make the code samples easier to read

I hope this is of help, cheers.