### PR TITLE
Using JAX-RS Status code

### DIFF
--- a/rest-client/README.md
+++ b/rest-client/README.md
@@ -118,7 +118,7 @@ The objects we're passing (i.e. Customer) are being marshaled by JAXB, Jackson, 
         //        Then
         assertEquals(deploymentURL + "rest/customer", webTarget.getUri().toASCIIString());
         assertEquals(MediaType.APPLICATION_JSON, response.getMediaType().toString());
-        assertEquals(HttpStatus.SC_OK, response.getStatus());
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
     }
 ```
 


### PR DESCRIPTION
#### Short description of what this resolves:

You are already using JAX-RS MediaType (in assertEquals(MediaType.APPLICATION_JSON), you might as well use the JAX-RS Status code instead of the HttpStatus from Apache Http components

