### PR TITLE
fix(travis): upgrades JDK version to unblock builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk11
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk11
 cache:
   directories:
     - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,12 @@
 
   <properties>
     <!-- Arquillian -->
-    <version.arquillian_core>1.4.1.Final</version.arquillian_core>
+    <version.arquillian_core>1.6.0.Final</version.arquillian_core>
     <version.arquillian_drone>1.1.0.Final</version.arquillian_drone>
-    <version.arquillian_warp>1.0.0.Alpha4</version.arquillian_warp>
+    <version.arquillian_warp>1.0.0</version.arquillian_warp>
 
     <!-- JAX-RS implementations -->
-    <version.resteasy_jax_rs_1_0>2.3.2.Final</version.resteasy_jax_rs_1_0>
+    <version.resteasy_jax_rs_1_0>2.3.7.Final</version.resteasy_jax_rs_1_0>
     <version.resteasy_jax_rs_2_0>3.0.4.Final</version.resteasy_jax_rs_2_0>
     <version.jersey>1.17</version.jersey>
     <version.cxf>2.7.2</version.cxf>
@@ -64,12 +64,12 @@
     <version.fest.assert>1.4</version.fest.assert>
     <version.shrinkwrap.resolvers>2.2.6</version.shrinkwrap.resolvers>
     <version.jboss_spec>3.0.0.Final</version.jboss_spec>
-    <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
+    <version.org.jboss.jbossas>2.1.1.Final</version.org.jboss.jbossas>
     <version.org.glassfish>3.1.2</version.org.glassfish>
 
     <!-- override from parent -->
-    <maven.compiler.target>1.5</maven.compiler.target>
-    <maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <tomcat.version>7.0.42</tomcat.version>
   </properties>
 
@@ -238,14 +238,14 @@
 
       <!-- Containers -->
       <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-container-managed</artifactId>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-container-managed</artifactId>
         <version>${version.org.jboss.jbossas}</version>
       </dependency>
 
       <dependency>
-        <groupId>org.jboss.as</groupId>
-        <artifactId>jboss-as-arquillian-container-remote</artifactId>
+        <groupId>org.wildfly.arquillian</groupId>
+        <artifactId>wildfly-arquillian-container-remote</artifactId>
         <version>${version.org.jboss.jbossas}</version>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <version.arquillian_warp>1.0.0</version.arquillian_warp>
 
     <!-- JAX-RS implementations -->
-    <version.resteasy_jax_rs_1_0>2.3.7.Final</version.resteasy_jax_rs_1_0>
+    <version.resteasy_jax_rs_1_0>3.6.3.Final</version.resteasy_jax_rs_1_0>
     <version.resteasy_jax_rs_2_0>3.0.4.Final</version.resteasy_jax_rs_2_0>
     <version.jersey>1.17</version.jersey>
     <version.cxf>2.7.2</version.cxf>

--- a/rest-client/ftest/ftest-impl-2x/pom.xml
+++ b/rest-client/ftest/ftest-impl-2x/pom.xml
@@ -22,7 +22,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.org.jboss.jbossas}</jboss.version>
+                <wildfly.version>${wildfly.version}</wildfly.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -39,12 +39,12 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <groupId>org.jboss.as</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <groupId>org.wildfly</groupId>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <overWrite>false</overWrite>
                       <type>zip</type>
-                      <version>${version.org.jboss.jbossas}</version>
+                      <version>${wildfly.version}</version>
                     </artifactItem>
                   </artifactItems>
                 </configuration>
@@ -55,8 +55,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -66,8 +66,8 @@
       <id>arq-jbossas-remote-7</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -128,8 +128,8 @@
     </dependency>
   </dependencies>
   <properties>
-    <jboss.version>7.1.1.Final</jboss.version>
-    <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <version.org.jboss.jbossas>2.1.1.Final</version.org.jboss.jbossas>
     <version.resteasy>2.3.2.Final</version.resteasy>
   </properties>
 </project>

--- a/rest-client/ftest/ftest-impl-2x/src/test/resources/arquillian.xml
+++ b/rest-client/ftest/ftest-impl-2x/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="jbossas7" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-${jboss.version:7.1.1.Final}</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/ftest/ftest-impl-3x/pom.xml
+++ b/rest-client/ftest/ftest-impl-3x/pom.xml
@@ -12,8 +12,8 @@
   <name>Arquillian REST Client Extension: Impl-3x Functional Tests</name>
   <properties>
     <version.resteasy>3.0.11.Final</version.resteasy>
-    <version.wildfly>9.0.2.Final</version.wildfly>
-    <arquillian.wildfly.version>1.1.0.Final</arquillian.wildfly.version>
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <arquillian.wildfly.version>2.1.1.Final</arquillian.wildfly.version>
   </properties>
   <profiles>
     <profile>
@@ -27,7 +27,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.wildfly}</jboss.version>
+                <jboss.version>${wildfly.version}</jboss.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -46,7 +46,7 @@
                     <artifactItem>
                       <groupId>org.wildfly</groupId>
                       <artifactId>wildfly-dist</artifactId>
-                      <version>${version.wildfly}</version>
+                      <version>${wildfly.version}</version>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <type>zip</type>
                       <overWrite>false</overWrite>

--- a/rest-client/ftest/ftest-impl-3x/src/test/resources/arquillian.xml
+++ b/rest-client/ftest/ftest-impl-3x/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="wildfly" default="true">
     <configuration>
-      <property name="jbossHome">target/wildfly-${version.wildfly:9.0.2.Final}</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/ftest/ftest-impl-jersey/pom.xml
+++ b/rest-client/ftest/ftest-impl-jersey/pom.xml
@@ -12,7 +12,7 @@
   <name>Arquillian REST Client Extension: Impl-Jersey Functional Tests</name>
   <profiles>
     <profile>
-      <id>arq-jbossas-managed-7</id>
+      <id>arq-wildfly-build-managed</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -22,7 +22,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.org.jboss.jbossas}</jboss.version>
+                <jboss.version>${wildfly.version}</jboss.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -39,12 +39,12 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <groupId>org.jboss.as</groupId>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${wildfly.version}</version>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
-                      <overWrite>false</overWrite>
                       <type>zip</type>
-                      <version>${version.org.jboss.jbossas}</version>
+                      <overWrite>false</overWrite>
                     </artifactItem>
                   </artifactItems>
                 </configuration>
@@ -55,20 +55,20 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
-          <version>${version.org.jboss.jbossas}</version>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <version>${arquillian.wildfly.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
     </profile>
     <profile>
-      <id>arq-jbossas-remote-7</id>
+      <id>arq-wildfly-build-remote</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
-          <version>${version.org.jboss.jbossas}</version>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
+          <version>${arquillian.wildfly.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -370,10 +370,10 @@
     </dependency>
   </dependencies>
   <properties>
-    <jboss.version>7.1.1.Final</jboss.version>
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <arquillian.wildfly.version>2.1.1.Final</arquillian.wildfly.version>
     <version.jersey>2.6</version.jersey>
     <version.jersey.providers>2.3.0</version.jersey.providers>
-    <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
     <version.resteasy>3.0.1.Final</version.resteasy>
   </properties>
 </project>

--- a/rest-client/ftest/ftest-impl-jersey/src/test/resources/arquillian.xml
+++ b/rest-client/ftest/ftest-impl-jersey/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="jbossas7" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-${jboss.version:7.1.1.Final}</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/impl/impl-2x/pom.xml
+++ b/rest-client/impl/impl-2x/pom.xml
@@ -13,7 +13,7 @@
   <description>Integrates RestEasy Client version 2.x with Arquillian</description>
   <properties>
     <jboss.version>7.1.1.Final</jboss.version>
-    <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
+    <version.org.jboss.jbossas>2.1.1.Final</version.org.jboss.jbossas>
     <version.resteasy>2.3.2.Final</version.resteasy>
   </properties>
   <dependencies>
@@ -97,7 +97,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.org.jboss.jbossas}</jboss.version>
+                <jboss.version>16.0.0.Final</jboss.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -111,12 +111,12 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <groupId>org.jboss.as</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <groupId>org.wildfly</groupId>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <overWrite>false</overWrite>
                       <type>zip</type>
-                      <version>${version.org.jboss.jbossas}</version>
+                      <version>16.0.0.Final</version>
                     </artifactItem>
                   </artifactItems>
                 </configuration>
@@ -130,8 +130,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -141,8 +141,8 @@
       <id>arq-jbossas-remote-7</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>

--- a/rest-client/impl/impl-2x/src/test/resources/arquillian.xml
+++ b/rest-client/impl/impl-2x/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="jbossas7" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-${jboss.version:7.1.1.Final}</property>
+      <property name="jbossHome">target/wildfly-${jboss.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/impl/impl-3x/pom.xml
+++ b/rest-client/impl/impl-3x/pom.xml
@@ -13,8 +13,8 @@
   <description>Integrates RestEasy Client version 3.x with Arquillian</description>
   <properties>
     <version.resteasy>3.0.11.Final</version.resteasy>
-    <version.wildfly>9.0.2.Final</version.wildfly>
-    <arquillian.wildfly.version>1.1.0.Final</arquillian.wildfly.version>
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <arquillian.wildfly.version>2.1.1.Final</arquillian.wildfly.version>
   </properties>
   <dependencies>
     <dependency>
@@ -102,7 +102,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.wildfly}</jboss.version>
+                <jboss.version>${wildfly.version}</jboss.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -121,7 +121,7 @@
                     <artifactItem>
                       <groupId>org.wildfly</groupId>
                       <artifactId>wildfly-dist</artifactId>
-                      <version>${version.wildfly}</version>
+                      <version>${wildfly.version}</version>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <type>zip</type>
                       <overWrite>false</overWrite>

--- a/rest-client/impl/impl-3x/src/test/resources/arquillian.xml
+++ b/rest-client/impl/impl-3x/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="wildfly" default="true">
     <configuration>
-      <property name="jbossHome">target/wildfly-${version.wildfly:9.0.2.Final}</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/impl/impl-jaxrs-2/pom.xml
+++ b/rest-client/impl/impl-jaxrs-2/pom.xml
@@ -100,7 +100,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.org.jboss.jbossas}</jboss.version>
+                <jboss.version>16.0.0.Final</jboss.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -114,12 +114,12 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <groupId>org.jboss.as</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <groupId>org.wildfly</groupId>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <overWrite>false</overWrite>
                       <type>zip</type>
-                      <version>${version.org.jboss.jbossas}</version>
+                      <version>16.0.0.Final</version>
                     </artifactItem>
                   </artifactItems>
                 </configuration>
@@ -133,8 +133,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -144,8 +144,8 @@
       <id>arq-jbossas-remote-7</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>

--- a/rest-client/impl/impl-jaxrs-2/src/test/resources/arquillian.xml
+++ b/rest-client/impl/impl-jaxrs-2/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="jbossas7" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-${jboss.version:7.1.1.Final}</property>
+      <property name="jbossHome">target/wildfly-${jboss.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/rest-client/impl/impl-jersey/pom.xml
+++ b/rest-client/impl/impl-jersey/pom.xml
@@ -23,7 +23,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <systemProperties>
-                <jboss.version>${version.org.jboss.jbossas}</jboss.version>
+                <wildfly.version>${wildfly.version}</wildfly.version>
               </systemProperties>
             </configuration>
           </plugin>
@@ -40,12 +40,12 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <groupId>org.jboss.as</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <groupId>org.wildfly</groupId>
                       <outputDirectory>${project.build.directory}/</outputDirectory>
                       <overWrite>false</overWrite>
                       <type>zip</type>
-                      <version>${version.org.jboss.jbossas}</version>
+                      <version>${wildfly.version}</version>
                     </artifactItem>
                   </artifactItems>
                 </configuration>
@@ -56,8 +56,8 @@
       </build>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -67,8 +67,8 @@
       <id>arq-jbossas-remote-7</id>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-remote</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-remote</artifactId>
           <version>${version.org.jboss.jbossas}</version>
           <scope>test</scope>
         </dependency>
@@ -142,8 +142,8 @@
     </dependency>
   </dependencies>
   <properties>
-    <jboss.version>7.1.1.Final</jboss.version>
-    <version.org.jboss.jbossas>7.1.1.Final</version.org.jboss.jbossas>
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <version.org.jboss.jbossas>2.1.1.Final</version.org.jboss.jbossas>
     <version.resteasy>2.3.2.Final</version.resteasy>
   </properties>
 </project>

--- a/rest-client/impl/impl-jersey/src/test/resources/arquillian.xml
+++ b/rest-client/impl/impl-jersey/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
 
   <container qualifier="jbossas7" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-${jboss.version:7.1.1.Final}</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
     </configuration>
   </container>
 

--- a/warp-rest/ftest/ftest-resteasy/pom.xml
+++ b/warp-rest/ftest/ftest-resteasy/pom.xml
@@ -45,47 +45,33 @@
     <dependency>
       <groupId>org.jboss.arquillian.extension</groupId>
       <artifactId>arquillian-rest-warp-impl-resteasy</artifactId>
-      <scope>test</scope>
     </dependency>
-
-<!--    <dependency>-->
-<!--      <groupId>org.jboss.arquillian.extension</groupId>-->
-<!--      <artifactId>arquillian-rest-warp-impl-jaxrs-2.0</artifactId>-->
-<!--      <scope>test</scope>-->
-<!--    </dependency>-->
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>3.6.3.Final</version>
+      <version>${version.resteasy_jax_rs_1_0}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-client</artifactId>
-      <version>3.6.3.Final</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jsapi</artifactId>
-      <version>3.6.3.Final</version>
+      <version>${version.resteasy_jax_rs_1_0}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
-      <version>3.6.3.Final</version>
+      <version>${version.resteasy_jax_rs_1_0}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson-provider</artifactId>
-      <version>3.6.3.Final</version>
+      <version>${version.resteasy_jax_rs_1_0}</version>
       <scope>test</scope>
     </dependency>
 

--- a/warp-rest/ftest/ftest-resteasy/pom.xml
+++ b/warp-rest/ftest/ftest-resteasy/pom.xml
@@ -14,14 +14,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>arquillian-rest-warp-ftest-resteasy</artifactId>
-  <packaging>jar</packaging>
+  <packaging>war</packaging>
 
   <name>Arquillian Warp REST Extension: Resteasy Functional Tests</name>
   <description>Resteasy Functional Tests for Arquillian Warp JAX-RS</description>
 
   <!-- Properties -->
   <properties>
-
+    <wildfly.version>16.0.0.Final</wildfly.version>
+    <arquillian.wildfly.version>2.1.1.Final</arquillian.wildfly.version>
   </properties>
 
   <!-- Licenses -->
@@ -47,30 +48,44 @@
       <scope>test</scope>
     </dependency>
 
+<!--    <dependency>-->
+<!--      <groupId>org.jboss.arquillian.extension</groupId>-->
+<!--      <artifactId>arquillian-rest-warp-impl-jaxrs-2.0</artifactId>-->
+<!--      <scope>test</scope>-->
+<!--    </dependency>-->
+
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxrs</artifactId>
-      <version>${version.resteasy_jax_rs_1_0}</version>
+      <version>3.6.3.Final</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>3.6.3.Final</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jsapi</artifactId>
-      <version>${version.resteasy_jax_rs_1_0}</version>
+      <version>3.6.3.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
-      <version>${version.resteasy_jax_rs_1_0}</version>
+      <version>3.6.3.Final</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jackson-provider</artifactId>
-      <version>${version.resteasy_jax_rs_1_0}</version>
+      <version>3.6.3.Final</version>
       <scope>test</scope>
     </dependency>
 
@@ -104,9 +119,15 @@
       </activation>
       <dependencies>
         <dependency>
-          <groupId>org.jboss.as</groupId>
-          <artifactId>jboss-as-arquillian-container-managed</artifactId>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
           <scope>test</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.jboss.resteasy</groupId>
+              <artifactId>resteasy-jaxrs</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.jboss.arquillian.protocol</groupId>
@@ -128,9 +149,9 @@
                 <configuration>
                   <artifactItems>
                     <artifactItem>
-                      <groupId>org.jboss.as</groupId>
-                      <artifactId>jboss-as-dist</artifactId>
-                      <version>7.1.1.Final</version>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${wildfly.version}</version>
                       <type>zip</type>
                       <overWrite>false</overWrite>
                       <outputDirectory>target</outputDirectory>
@@ -147,5 +168,3 @@
   </profiles>
 
 </project>
-
-

--- a/warp-rest/ftest/ftest-resteasy/src/main/java/org/jboss/arquillian/quickstart/resteasy/application/StockApplication.java
+++ b/warp-rest/ftest/ftest-resteasy/src/main/java/org/jboss/arquillian/quickstart/resteasy/application/StockApplication.java
@@ -17,8 +17,13 @@
  */
 package org.jboss.arquillian.quickstart.resteasy.application;
 
+import org.jboss.arquillian.extension.rest.warp.impl.resteasy.integration.WarpResteasyInterceptor;
+import org.jboss.arquillian.quickstart.resteasy.service.rs.StockServiceResource;
+
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * The stock application.
@@ -28,4 +33,15 @@ import javax.ws.rs.core.Application;
 @ApplicationPath("/rest")
 public class StockApplication extends Application {
 
+    @Override
+    public Set<Class<?>> getClasses() {
+        // TODO the WARP interceptor needs to be added explicitly, due to the fact
+        // that this deployment uses explicit dispatcher servlet
+        return Collections.<Class<?>>singleton(WarpResteasyInterceptor.class);
+    }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return Collections.<Object>singleton(new StockServiceResource());
+    }
 }

--- a/warp-rest/ftest/ftest-resteasy/src/test/java/org/jboss/arquillian/quickstart/resteasy/service/rs/Deployments.java
+++ b/warp-rest/ftest/ftest-resteasy/src/test/java/org/jboss/arquillian/quickstart/resteasy/service/rs/Deployments.java
@@ -23,12 +23,15 @@ final class Deployments {
      *
      * @return the test deployment
      */
-    public static WebArchive createDeployment(String name) {
+    public static Archive createDeployment() {
         File[] libs = loadLibraries();
 
-        return ShrinkWrap.create(WebArchive.class, name + ".war")
+        return ShrinkWrap.create(WebArchive.class)
             .addClasses(StockApplication.class, Stock.class, StockService.class, StockServiceResource.class)
+            .addAsWebInfResource("WEB-INF/web.xml")
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsWebResource("restclient.jsp")
+            .addAsWebResource("js/jquery-1.8.2.min.js", "js/jquery-1.8.2.min.js")
             .addAsLibraries(libs);
     }
 
@@ -38,6 +41,8 @@ final class Deployments {
      * @return the loaded dependencies
      */
     private static File[] loadLibraries() {
-        return Maven.resolver().resolve("org.easytesting:fest-assert:1.4", "org.jboss.resteasy:resteasy-jaxrs:3.6.3.Final").withTransitivity().asFile();
+        return Maven.resolver().resolve("org.jboss.resteasy:resteasy-jaxrs:3.6.3.Final",
+            "org.jboss.resteasy:resteasy-jaxb-provider:3.6.3.Final",
+            "org.easytesting:fest-assert:1.4").withTransitivity().asFile();
     }
 }

--- a/warp-rest/ftest/ftest-resteasy/src/test/java/org/jboss/arquillian/quickstart/resteasy/service/rs/Deployments.java
+++ b/warp-rest/ftest/ftest-resteasy/src/test/java/org/jboss/arquillian/quickstart/resteasy/service/rs/Deployments.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.quickstart.resteasy.model.Stock;
 import org.jboss.arquillian.quickstart.resteasy.service.StockService;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
@@ -22,14 +23,12 @@ final class Deployments {
      *
      * @return the test deployment
      */
-    public static Archive createDeployment() {
+    public static WebArchive createDeployment(String name) {
         File[] libs = loadLibraries();
 
-        return ShrinkWrap.create(WebArchive.class)
+        return ShrinkWrap.create(WebArchive.class, name + ".war")
             .addClasses(StockApplication.class, Stock.class, StockService.class, StockServiceResource.class)
-            .addAsWebInfResource("WEB-INF/web.xml")
-            .addAsWebResource("restclient.jsp")
-            .addAsWebResource("js/jquery-1.8.2.min.js", "js/jquery-1.8.2.min.js")
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsLibraries(libs);
     }
 
@@ -39,6 +38,6 @@ final class Deployments {
      * @return the loaded dependencies
      */
     private static File[] loadLibraries() {
-        return Maven.resolver().resolve("org.easytesting:fest-assert:1.4").withTransitivity().asFile();
+        return Maven.resolver().resolve("org.easytesting:fest-assert:1.4", "org.jboss.resteasy:resteasy-jaxrs:3.6.3.Final").withTransitivity().asFile();
     }
 }

--- a/warp-rest/ftest/ftest-resteasy/src/test/resources/WEB-INF/web.xml
+++ b/warp-rest/ftest/ftest-resteasy/src/test/resources/WEB-INF/web.xml
@@ -3,16 +3,29 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
 
   <listener>
-    <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
+    <listener-class>
+      org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap
+    </listener-class>
   </listener>
 
   <servlet>
-    <servlet-name>RESTEasy JSAPI</servlet-name>
-    <servlet-class>org.jboss.resteasy.jsapi.JSAPIServlet</servlet-class>
+    <servlet-name>Resteasy</servlet-name>
+    <servlet-class>
+      org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher
+    </servlet-class>
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.jboss.arquillian.quickstart.resteasy.application.StockApplication</param-value>
+    </init-param>
   </servlet>
 
   <servlet-mapping>
-    <servlet-name>RESTEasy JSAPI</servlet-name>
-    <url-pattern>/rest-js</url-pattern>
+    <servlet-name>Resteasy</servlet-name>
+    <url-pattern>/rest/*</url-pattern>
   </servlet-mapping>
+
+  <context-param>
+    <param-name>resteasy.servlet.mapping.prefix</param-name>
+    <param-value>/rest/</param-value>
+  </context-param>
 </web-app>

--- a/warp-rest/ftest/ftest-resteasy/src/test/resources/arquillian.xml
+++ b/warp-rest/ftest/ftest-resteasy/src/test/resources/arquillian.xml
@@ -13,7 +13,7 @@
 
   <container qualifier="jbossas-managed" default="true">
     <configuration>
-      <property name="jbossHome">target/jboss-as-7.1.1.Final</property>
+      <property name="jbossHome">target/wildfly-${wildfly.version:16.0.0.Final}</property>
       <property name="outputToConsole">true</property>
     </configuration>
   </container>

--- a/warp-rest/impl/impl-resteasy/pom.xml
+++ b/warp-rest/impl/impl-resteasy/pom.xml
@@ -58,9 +58,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.spec</groupId>
-      <artifactId>jboss-javaee-web-6.0</artifactId>
-      <type>pom</type>
+      <groupId>javax</groupId>
+      <artifactId>javaee-web-api</artifactId>
+      <version>7.0</version>
       <scope>provided</scope>
     </dependency>
 
@@ -104,4 +104,3 @@
   </dependencies>
 
 </project>
-

--- a/warp-rest/impl/impl-resteasy/src/main/java/org/jboss/arquillian/extension/rest/warp/impl/resteasy/integration/WarpResteasyInterceptor.java
+++ b/warp-rest/impl/impl-resteasy/src/main/java/org/jboss/arquillian/extension/rest/warp/impl/resteasy/integration/WarpResteasyInterceptor.java
@@ -19,7 +19,7 @@ package org.jboss.arquillian.extension.rest.warp.impl.resteasy.integration;
 
 import org.jboss.arquillian.extension.rest.warp.api.RestContext;
 import org.jboss.resteasy.annotations.interception.ServerInterceptor;
-import org.jboss.resteasy.core.ResourceMethod;
+import org.jboss.resteasy.core.ResourceMethodInvoker;
 import org.jboss.resteasy.core.ServerResponse;
 import org.jboss.resteasy.spi.Failure;
 import org.jboss.resteasy.spi.HttpRequest;
@@ -82,7 +82,7 @@ public class WarpResteasyInterceptor implements PreProcessInterceptor, PostProce
      * {@inheritDoc}
      */
     @Override
-    public ServerResponse preProcess(HttpRequest httpRequest, ResourceMethod resourceMethod)
+    public ServerResponse preProcess(HttpRequest httpRequest, ResourceMethodInvoker resourceMethod)
         throws Failure, WebApplicationException {
 
         // stores the http request


### PR DESCRIPTION
#### Short description of what this resolves:

This should fix travis builds failing because of JDK version being below the expected

#### Changes proposed in this pull request:

- Upgrade openjdk to version 8

Fixes #75
